### PR TITLE
Add a reference to the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # Initial page
 
+VTIL's API documentation is available on https://docs.vtil.org


### PR DESCRIPTION
I couldn't find where the API documentation was deployed in, so I think it will be a good idea to at least document it in the README.
I also suggest adding this URL in the repository's settings so it will appear in the sidebar